### PR TITLE
Add arm64 Docker image

### DIFF
--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -48,3 +48,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -30,6 +30,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4.0.1

--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -36,10 +36,15 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      # Set up QEMU to allow multi plattform builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This automatically builds a multi-arch container with amd64 and arm64 support using GitHub Actions and uses GitHub Actions cache to speed up build processes. 